### PR TITLE
show conn reuse

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"net/http/httptrace"
 	"time"
 )
 
@@ -16,9 +17,14 @@ func httpClient() *http.Client {
 	}
 }
 
-func getHTTPRequest(ctx context.Context) (*http.Request, context.CancelFunc) {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(time.Millisecond*80))
-	request, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:9001/", nil)
+func getHTTPRequest(ctx context.Context, timeout time.Duration) (*http.Request, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	trace := &httptrace.ClientTrace{
+		GotConn: func(connInfo httptrace.GotConnInfo) {
+			log.Printf("[CLIENT] reused/old connection?: %+v\n", connInfo.Reused)
+		},
+	}
+	request, _ := http.NewRequestWithContext(httptrace.WithClientTrace(ctx, trace), http.MethodGet, "http://localhost:9001/", nil)
 	return request, cancel
 }
 
@@ -28,21 +34,40 @@ func Client(w http.ResponseWriter, r *http.Request) {
 	// custom http client to resue the TCP connection
 	c := httpClient()
 
-	// 1st request
-	req, cancelContext := getHTTPRequest(r.Context())
+	// 1st request, no conn in pool, GotConn.Reused should be false
+	req, cancelContext := getHTTPRequest(r.Context(), time.Millisecond*80)
 	defer cancelContext()
 	_, err := c.Do(req)
 	if err != nil {
 		log.Printf("[CLIENT] %v", err)
 	}
 
-	// 2nd request
-	req, cancelContext = getHTTPRequest(r.Context())
+	// 2nd request, first request should have timed out, no conn in pool, GetConn.Reused should be false
+	req, cancelContext = getHTTPRequest(r.Context(), time.Millisecond*80)
 	defer cancelContext()
 	_, err = c.Do(req)
 	if err != nil {
 		log.Printf("[CLIENT] %v", err)
 	}
+
+	// 3rd request, previous request should have timed out, no conn in pool. GetConn.Reused should be false
+	req, cancelContext = getHTTPRequest(r.Context(), time.Second*80)
+	defer cancelContext()
+	_, err = c.Do(req)
+	if err != nil {
+		log.Printf("[CLIENT] %v", err)
+	}
+
+	// 4th request, previous request hould not have timed out, 1 conn in poll, GetConn.Reused should be true
+	req, cancelContext = getHTTPRequest(r.Context(), time.Second*80)
+	defer cancelContext()
+	_, err = c.Do(req)
+	if err != nil {
+		log.Printf("[CLIENT] %v", err)
+	}
+
+	// 1st/2nd request show: Example above shows that when context is canceled, connection is killed and not put in conn pool
+	// 3rd/4th request how: After a successful request, the connection is put in the pool and reused for subsequent requests.
 
 	log.Println("[CLIENT] stopped")
 }


### PR DESCRIPTION
couple of comments about ur observation

>If context timeout kills a TCP connection, we would expect to see a failure for the 2nd http request from the client to the middleware. But from this demo it was evident that we succesfully sent an HTTP request to the middleware.

why would we expect a failure on the 2nd request? a new conn would be spun up to serve it

>If context timeout kills a TCP connection, we would expect that once the 80 msec context times out, the middleware process ends and it drops the request in the middle of its sleep. In reality though, the connection between client and middleware is not affected by the request's context timeout. And that is testified when middleware succesfully wakes up from its short 2 sec nap.

i think there's some confusion here. you're assuming goroutine is the "connection", what actually happens is the middleware server starts up a http server that accepts new http conns. the http server likely itself is a long running goroutine. when receiving requests, it'll spin up additional goroutines to handle the request. ur sleep is in that goroutine. if u want that app logic to be context aware, a sleep will not work (its blocking). you can use a select instead:
```
// sub ur sleep with this
select {
	case <-time.After(2 * time.Second):
	case <-r.Context().Done():
		log.Println("[MIDDLEWARE] context canceled")
		http.Error(w, r.Context().Err().Error(), 500)
		return
	}
```

the code i changed uses `httptrace` to inspect the connection state. im trying to point out the scenario where a conn is reused or created. the 1st and 2nd show that a timeout causing the next conn to be new. whereas the 3rd and 4th show that with no timeout, a conn is reused
